### PR TITLE
FIX: replace cargo wasi (deprecated) with cargo component

### DIFF
--- a/devel/lib_functions.sh
+++ b/devel/lib_functions.sh
@@ -26,7 +26,7 @@ generate_wasm_yaml_file() {
 
     cat <<EOF
 name: ${NAME}${CONTROLLER_NR}
-wasm: ./ring-rust-example.wasi.controller${CONTROLLER_NR}.wasm
+wasm: ./ring-rust-example.controller${CONTROLLER_NR}.wasm
 env:
 - name: RUST_LOG
   value: "info"

--- a/devel/setup_wasm_rust.sh
+++ b/devel/setup_wasm_rust.sh
@@ -32,20 +32,20 @@ mkdir -p bin_wasm/
 
 # Compile the ring controller once with "REPLACE_MEREPLACE_ME" as nonce
 echo ">> Build the controller wasm rust"
-COMPILE_NONCE="REPLACE_MEREPLACE_ME" cargo wasi build --release --features client-wasi
+COMPILE_NONCE="REPLACE_MEREPLACE_ME" cargo component build --release --features client-wasi
 echo ">> optimise wasm"
-# why use wasm opt when it is default already optimised using cargo wasi
+# why use wasm opt when it is default already optimised using cargo component
 wasm-opt --version
-#wasm-opt -Os ./target/wasm32-wasi/release/ring-pod-example.wasi.wasm -o ./target/wasm32-wasi/release/ring-pod-example.wasi.opt.wasm
-#cp ./target/wasm32-wasi/release/ring-pod-example.wasi.opt.wasm ./bin_wasm/ring-rust-example.wasi.REPLACE_ME.wasm
-cp ./target/wasm32-wasi/release/ring-pod-example.wasi.wasm ./bin_wasm/ring-rust-example.wasi.REPLACE_ME.wasm
+#wasm-opt -Os ./target/wasm32-wasip1/release/ring-pod-example.wasm -o ./target/wasm32-wasip1/release/ring-pod-example.opt.wasm
+#cp ./target/wasm32-wasip1/release/ring-pod-example.opt.wasm ./bin_wasm/ring-rust-example.REPLACE_ME.wasm
+cp ./target/wasm32-wasip1/release/ring-pod-example.wasm ./bin_wasm/ring-rust-example.REPLACE_ME.wasm
 
 # Create unique versions of the controller by replacing the "REPLACE_MEREPLACE_ME" nonce value
 echo ">> Create variants"
 for ((i = 0; i < NR_CONTROLLERS; i++)); do
     CONTROLLER_NAME="controller${i}"
     NONCE_VALUE=$(echo $CONTROLLER_NAME | md5sum | head -c 20)
-    sed -e "s|REPLACE_MEREPLACE_ME|$NONCE_VALUE|" ./bin_wasm/ring-rust-example.wasi.REPLACE_ME.wasm >./bin_wasm/ring-rust-example.wasi.$CONTROLLER_NAME.wasm
+    sed -e "s|REPLACE_MEREPLACE_ME|$NONCE_VALUE|" ./bin_wasm/ring-rust-example.REPLACE_ME.wasm >./bin_wasm/ring-rust-example.$CONTROLLER_NAME.wasm
     CONTROLLER_NAMES+=($CONTROLLER_NAME)
 done
 popd

--- a/devel/setup_wasm_rust_simple.sh
+++ b/devel/setup_wasm_rust_simple.sh
@@ -37,21 +37,21 @@ mkdir -p bin_wasm/
 
 # Compile the ring controller once with "REPLACE_MEREPLACE_ME" as nonce
 echo ">> Build the controller wasm rust"
-cargo wasi build --release --features client-wasi
+cargo component build --release --features client-wasi
 echo ">> optimise wasm"
-# why use wasm opt when it is default already  optimised using  cargo wasi
+# why use wasm opt when it is default already  optimised using  cargo component
 #wasm-opt --version
-wasm-opt -Os ./target/wasm32-wasi/release/simple-pod-example.wasi.wasm -o ./target/wasm32-wasi/release/simple-pod-example.wasi.wasm1
-#wasm-opt -Os ./target/wasm32-wasi/release/ring-pod-example.wasi.wasm -o ./target/wasm32-wasi/release/ring-pod-example.wasi.opt.wasm
-#cp ./target/wasm32-wasi/release/ring-pod-example.wasi.opt.wasm ./bin_wasm/ring-rust-example.wasi.REPLACE_ME.wasm
-cp ./target/wasm32-wasi/release/simple-pod-example.wasi.wasm1 ./bin_wasm/simple-pod-example.wasm
+wasm-opt -Os ./target/wasm32-wasip1/release/simple-pod-example.wasm -o ./target/wasm32-wasip1/release/simple-pod-example.wasm1
+#wasm-opt -Os ./target/wasm32-wasip1/release/ring-pod-example.wasm -o ./target/wasm32-wasip1/release/ring-pod-example.opt.wasm
+#cp ./target/wasm32-wasip1/release/ring-pod-example.opt.wasm ./bin_wasm/ring-rust-example.REPLACE_ME.wasm
+cp ./target/wasm32-wasip1/release/simple-pod-example.wasm1 ./bin_wasm/simple-pod-example.wasm
 
 # Create unique versions of the controller by replacing the "REPLACE_MEREPLACE_ME" nonce value
 #echo ">> Create variants"
 #for (( i = 0; i < NR_CONTROLLERS; i++ )); do
 #    CONTROLLER_NAME="controller${i}"
 #   NONCE_VALUE=$(echo $CONTROLLER_NAME | md5sum | head -c 20)
-#   sed -e "s|REPLACE_MEREPLACE_ME|$NONCE_VALUE|" ./bin_wasm/ring-rust-example.wasi.REPLACE_ME.wasm > ./bin_wasm/ring-rust-example.wasi.$CONTROLLER_NAME.wasm
+#   sed -e "s|REPLACE_MEREPLACE_ME|$NONCE_VALUE|" ./bin_wasm/ring-rust-example.REPLACE_ME.wasm > ./bin_wasm/ring-rust-example.$CONTROLLER_NAME.wasm
 #   CONTROLLER_NAMES+=($CONTROLLER_NAME)
 #done
 popd

--- a/devel/tool.sh
+++ b/devel/tool.sh
@@ -110,8 +110,8 @@ check_tool_rust() {
     source $HOME/.cargo/env
   }
 
-  rustup target add wasm32-wasi
-  cargo install cargo-wasi
+  rustup target add wasm32-wasip1
+  cargo install cargo-component
 
   check_tool sccache
   RUSTC_WRAPPER=sccache

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,6 +17,7 @@ We will highlight which shell file automates the process
 ### Compiling the projects
 
 - [Rust](https://www.rust-lang.org/) - Required to build the parent controller and child controllers
+- [Cargo component](https://github.com/bytecodealliance/cargo-component) - Easier to build WASM with included interfaces
 - [Go](https://go.dev/) - Required to build the `ring-go-controller` which is used as a comparison
 - [Cross](https://crates.io/crates/cross) - Easier cross-compilation than with cargo, while providing isolation through Docker containers
 - [wasm-opt](https://github.com/WebAssembly/binaryen) - Required to optimize the WASM output from cross

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,7 +58,7 @@ Below is an example on how to setup the **simple-rust-controller** example.
 mkdir temp
 cp ./pkg/controller/target/x86_64-unknown-linux-musl/release/controller ./temp
 cp ./tests/wasm_rust_simple/wasm_config.yaml ./temp
-cp ./controllers/target/wasm32-wasip1/release/${NAME_OPERATOR}-optimized.wasi.wasm ./temp
+cp ./controllers/target/wasm32-wasip1/release/${NAME_OPERATOR}-optimized.wasm ./temp
 docker build -f ./tests/wasm_rust_simple/Dockerfile -t wasm_rust_simple:controller ./temp
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,9 +39,9 @@ We provide an example configuration in [tests/wasm_rust_simple/wasm_config.yaml]
 ```sh
 export NAME_OPERATOR="simple-pod-example"
 # Build the WASM for the child operator
-cargo wasi build --release --features client-wasi
+cargo component build --release --features client-wasi
 # Optimize the WASM
-wasm-opt -Os ./target/wasm32-wasi/release/${NAME_OPERATOR}.wasi.wasm -o ./target/wasm32-wasi/release/${NAME_OPERATOR}-optimized.wasi.wasm
+wasm-opt -Os ./target/wasm32-wasip1/release/${NAME_OPERATOR}.wasm -o ./target/wasm32-wasip1/release/${NAME_OPERATOR}-optimized.wasm
 ```
 
 ### Building the complete Docker image and loading into Kind
@@ -58,7 +58,7 @@ Below is an example on how to setup the **simple-rust-controller** example.
 mkdir temp
 cp ./pkg/controller/target/x86_64-unknown-linux-musl/release/controller ./temp
 cp ./tests/wasm_rust_simple/wasm_config.yaml ./temp
-cp ./controllers/target/wasm32-wasi/release/${NAME_OPERATOR}-optimized.wasi.wasm ./temp
+cp ./controllers/target/wasm32-wasip1/release/${NAME_OPERATOR}-optimized.wasi.wasm ./temp
 docker build -f ./tests/wasm_rust_simple/Dockerfile -t wasm_rust_simple:controller ./temp
 ```
 

--- a/pkg/controller/Cargo.toml
+++ b/pkg/controller/Cargo.toml
@@ -47,7 +47,7 @@ pin-project = "^1.0.10"
 crossbeam-channel = "0.4.4"
 chrono = "0.4.10"
 
-reqwest = { version = "0.11", default_features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 
 [profile.release]


### PR DESCRIPTION
As indicated by the title, the project is no longer buildable on the most recent Rust versions.
An explanation on the reasons why it happened and I went with this solution, can be found [in the findings section of my repo](https://github.com/idlab-discover/masters-robbe-haegeman/blob/1cfbe5d91631466895611e0682076e50b23e0ee4/thesis_resources/findings/transition_to_wasip.md).

`cargo component` would be used as a drop-in replacement to `cargo wasi`, with the only other changes being paths.

This PR is marked as Draft to allow other maintainers to update their toolchains before merging.